### PR TITLE
Data object could be null in error handler

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,9 @@ function parseResponse(err, response, body){
   //we also we want this to be a real error object...
   if (!err && (response.statusCode < 200 || response.statusCode > 206)){
     err = new Error('HTTP request error. Check errors object.');
-    err.errors = data.errors;
+    if (typeof data === 'object' && data !== null) {
+      err.errors = data.errors;
+    }
     err.code = response.statusCode;
   }
 


### PR DESCRIPTION
If a response does not include a full JSON response body, the data variable can be null. Which causes an error to be thrown on line 62 when reading the errors object from the response data.

```
TypeError: Cannot read property 'errors' of null
```